### PR TITLE
Implement video upload progress & fullscreen fix

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -90,6 +90,12 @@ textarea {
   background-color: #234bcc;
 }
 
+progress {
+  width: 100%;
+  height: 8px;
+  margin-top: 0.5rem;
+}
+
 .filter-box {
   display: flex;
   flex-wrap: wrap;

--- a/static/videos.js
+++ b/static/videos.js
@@ -89,12 +89,26 @@ async function uploadVideo(e) {
   e.preventDefault();
   const form = e.target;
   const formData = new FormData(form);
-  await fetch("/add-video", {
-    method: "POST",
-    body: formData,
+  const progress = document.getElementById("upload-progress");
+  progress.style.display = "block";
+  progress.value = 0;
+  const xhr = new XMLHttpRequest();
+  xhr.open("POST", "/add-video");
+  xhr.upload.addEventListener("progress", (evt) => {
+    if (evt.lengthComputable) {
+      progress.value = (evt.loaded / evt.total) * 100;
+    }
   });
-  form.reset();
-  fetchVideos();
+  xhr.onload = () => {
+    progress.style.display = "none";
+    form.reset();
+    fetchVideos();
+  };
+  xhr.onerror = () => {
+    progress.style.display = "none";
+    alert("Upload failed");
+  };
+  xhr.send(formData);
 }
 
 // 체크된 영상 삭제 요청
@@ -165,5 +179,9 @@ function extractYoutubeID(url) {
   return match ? match[1] : url;
 }
 
-window.addEventListener("resize", renderTable);
-// 화면 크기가 바뀌면 테이블을 다시 그려 모바일 레이아웃을 유지
+window.addEventListener("resize", () => {
+  if (!document.fullscreenElement) {
+    renderTable();
+  }
+});
+// 화면 크기가 바뀌면 테이블을 다시 그리되 전체화면 시에는 동작하지 않음

--- a/templates/videos.html
+++ b/templates/videos.html
@@ -44,6 +44,7 @@
             <input type="file" name="video_file" accept="video/*" />
           </div>
           <button type="submit" class="submit-btn">저장</button>
+          <progress id="upload-progress" value="0" max="100" style="display:none; width:100%; margin-top:0.5rem;"></progress>
         </form>
       </section>
       <section class="records">


### PR DESCRIPTION
## Summary
- show a progress element during video uploads
- style the `progress` bar
- don't re-render the table when the page resizes in fullscreen

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6848832427a08322bd3862b58b4cb1f0